### PR TITLE
Nl means: use lookup table for exp(-x)

### DIFF
--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -493,7 +493,6 @@ cdef inline _integral_image_3d(IMGDTYPE [:, :, ::] padded,
     by avoiding copies of ``padded``.
     """
     cdef int pln, row, col
-    cdef float distance
     for pln in range(max(1, -t_pln), min(n_pln, n_pln - t_pln)):
         for row in range(max(1, -t_row), min(n_row, n_row - t_row)):
             for col in range(max(1, -t_col), min(n_col, n_col - t_col)):

--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -5,7 +5,7 @@ from libc.math cimport exp
 
 ctypedef np.float32_t IMGDTYPE
 
-cdef float DISTANCE_CUTOFF = 5.
+cdef double DISTANCE_CUTOFF = 5.0
 
 @cython.boundscheck(False)
 cdef inline float patch_distance_2d(IMGDTYPE [:, :] p1,
@@ -696,7 +696,8 @@ def _fast_nl_means_denoising_3d(image, int s=5, int d=7, float h=0.1):
                 if t_col == 0 and (t_pln is not 0 or t_row is not 0):
                     alpha = 0.5
                 else:
-                    alpha = 1.
+                    alpha = 1.0
+
                 # Compute integral image of the squared difference between
                 # padded and the same image shifted by (t_pln, t_row, t_col)
                 integral = np.zeros_like(padded)

--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -1,11 +1,13 @@
 import numpy as np
 cimport numpy as np
 cimport cython
-from libc.math cimport exp
 
 ctypedef np.float64_t IMGDTYPE
 
 cdef double DISTANCE_CUTOFF = 5.0
+
+cdef extern from "fast_exp.h":
+    double fast_exp "EXP" (double)
 
 @cython.boundscheck(False)
 cdef inline double patch_distance_2d(IMGDTYPE [:, :] p1,
@@ -51,7 +53,7 @@ cdef inline double patch_distance_2d(IMGDTYPE [:, :] p1,
         for j in range(s):
             tmp_diff = p1[i, j] - p2[i, j]
             distance += (w[i, j] * tmp_diff * tmp_diff)
-    distance = exp(-distance)
+    distance = fast_exp(-distance)
     return distance
 
 
@@ -97,7 +99,7 @@ cdef inline double patch_distance_2drgb(IMGDTYPE [:, :, :] p1,
             for color in range(3):
                 tmp_diff = p1[i, j, color] - p2[i, j, color]
                 distance += w[i, j] * tmp_diff * tmp_diff
-    distance = exp(-distance)
+    distance = fast_exp(-distance)
     return distance
 
 
@@ -141,7 +143,7 @@ cdef inline double patch_distance_3d(IMGDTYPE [:, :, :] p1,
             for k in range(s):
                 tmp_diff = p1[i, j, k] - p2[i, j, k]
                 distance += w[i, j, k] * tmp_diff * tmp_diff
-    distance = exp(-distance)
+    distance = fast_exp(-distance)
     return distance
 
 
@@ -594,7 +596,7 @@ def _fast_nl_means_denoising_2d(image, int s=7, int d=13, double h=0.1):
                     # exp of large negative numbers is close to zero
                     if distance > DISTANCE_CUTOFF:
                         continue
-                    weight = alpha * exp(-distance)
+                    weight = alpha * fast_exp(-distance)
                     # Accumulate weights corresponding to different shifts
                     weights[row, col] += weight
                     weights[row + t_row, col + t_col] += weight
@@ -716,7 +718,8 @@ def _fast_nl_means_denoising_3d(image, int s=5, int d=7, double h=0.1):
                             # exp of large negative numbers is close to zero
                             if distance > DISTANCE_CUTOFF:
                                 continue
-                            weight = alpha * exp(-distance)
+
+                            weight = alpha * fast_exp(-distance)
                             # Accumulate weights for the different shifts
                             weights[pln, row, col] += weight
                             weights[pln + t_pln, row + t_row,

--- a/skimage/restoration/fast_exp.h
+++ b/skimage/restoration/fast_exp.h
@@ -1,0 +1,24 @@
+#include <math.h>
+
+/* A fast approximation of the exponential function.
+ * Reference: https://schraudolph.org/pubs/Schraudolph99.pdf */
+
+static union
+{
+    double d;
+    struct
+    {
+
+#ifdef LITTLE_ENDIAN
+    int j, i;
+#else
+    int i, j;
+#endif
+    } n;
+} _eco;
+
+#define EXP_A (1048576/M_LN2) /* use 1512775 for integer version */
+#define EXP_C 60801           /* for min. RMS error */
+/* #define EXP_C 45799 */     /* for min. max. relative error */
+/* #define EXP_C 68243 */     /* for min. mean relative error */
+#define EXP(y) (_eco.n.i = EXP_A*(y) + (1072693248 - EXP_C), _eco.d)


### PR DESCRIPTION
As discussed in scikit-image/scikit-image#2878, here is a look-up table based implementation for the exp(-x) calls in non-local means.  

For those unfamiliar with lookup tables, it is the same concept used for the sine-based example here:
https://en.wikipedia.org/wiki/Lookup_table#Computing_sines

The table is only computed for exp(-x) for x in range [0, DISTANCE_CUTOFF].  I have clipped values below 0 to 1.0 and above DISTANCE_CUTOFF to 0.0.

The highest error in the test case included here is slightly less than 1e-7.  Higher or lower accuracy can be obtained by adjusting the TABLE_PRECISION variable (related to the size of the table used).

The overhead in generating the lookup table is negligible in the context of non-local means as it is just generated once outside of the loops over patches.